### PR TITLE
Fix Cleanroom Loader crash

### DIFF
--- a/src/main/java/com/charles445/rltweaker/asm/patch/PatchEnchant.java
+++ b/src/main/java/com/charles445/rltweaker/asm/patch/PatchEnchant.java
@@ -95,6 +95,7 @@ public class PatchEnchant extends PatchManager
 				addNode.owner = owner_HookEnchant;
 				addNode.name = "addEnchantmentRestricted";
 				addNode.desc = "(Ljava/util/List;Lnet/minecraft/enchantment/Enchantment;)Z";
+				addNode.itf = false;
 			}
 		});
 		


### PR DESCRIPTION
Fixes a crash with Cleanroom Loader that occurs when `EnchantRandomly#apply` is called. The error was `java.lang.IncompatibleClassChangeError: Method 'boolean com.charles445.rltweaker.hook.HookEnchant.addEnchantmentRestricted(java.util.List, net.minecraft.enchantment.Enchantment)' must be Methodref constant` 