### PR TITLE
fixed typo

### DIFF
--- a/src/main/java/com/charles445/rltweaker/reflect/BetterSurvivalReflect.java
+++ b/src/main/java/com/charles445/rltweaker/reflect/BetterSurvivalReflect.java
@@ -39,7 +39,7 @@ public class BetterSurvivalReflect
 	
 	public BetterSurvivalReflect() throws Exception
 	{
-		c_NunchakuComboProvider = Class.forName("com.mujmajnkraft.bettersurvival.capabilities.nunchakucombo.NunchakuComboProwider");
+		c_NunchakuComboProvider = Class.forName("com.mujmajnkraft.bettersurvival.capabilities.nunchakucombo.NunchakuComboProvider");
 		f_NunchakuComboProvider_NUNCHAKUCOMBO_CAP = ReflectUtil.findField(c_NunchakuComboProvider, "NUNCHAKUCOMBO_CAP");
 		o_NUNCHAKUCOMBO_CAP = (Capability) f_NunchakuComboProvider_NUNCHAKUCOMBO_CAP.get(null);
 		


### PR DESCRIPTION
Failed to setup BetterSurvivalHandler!
java.lang.ClassNotFoundException: com.mujmajnkraft.bettersurvival.capabilities.nunchakucombo.NunchakuComboProwider

fixed in BS by fonny in 2022
https://github.com/mujmajnkraft/BetterSurvival/commit/3636da0748ca0e98d0ae73ffd9b66eef20f581a8

idk how this got unnoticed since then
do we even still need that fix?