### PR TITLE
Simple fix to save mount from being deleted by Drop Disconnect Lag Dupe fix

### DIFF
--- a/src/main/java/com/charles445/rltweaker/handler/MinecraftHandler.java
+++ b/src/main/java/com/charles445/rltweaker/handler/MinecraftHandler.java
@@ -461,6 +461,7 @@ public class MinecraftHandler
 			return;
 		if (event.player.world.isRemote)
 			return;
+		event.player.dismountRidingEntity();
 		MinecraftServer server = event.player.getServer();
 		server.futureTaskQueue.add(new FutureTask<>(() -> {
 			WRITE_PLAYER_DATA.invoke(server.getPlayerList(), (EntityPlayerMP) event.player);


### PR DESCRIPTION
To fix https://github.com/Meldexun/RLTweaker/issues/18
Vanilla Server behavior is player can logout on a mount and relog mounted on the entity. This fix prevents the mounted entity from being deleted by dismounting the player before vanilla saves and processes mounts, however it does not remount the player on login.

Vanilla behavior of PlayerList.playerLoggedOut() goes in this order:
1. Writes Player Data
2. Check and remove mounted entities from world.

Behavior with Fix Drop Disconnect Lag Dupe enabled is generally this:
1. RLTweaker Queues Writes Player Data
2. Vanilla Writes Player Data
3. Vanilla checks and removes mounted entities from world
4. RLTweaker Writes Player Data